### PR TITLE
Changed Dubious Disc description to prevent overflow

### DIFF
--- a/src/data/items.h
+++ b/src/data/items.h
@@ -3682,7 +3682,7 @@ const struct Item gItemsInfo[] =
         .name = _("Dubious Disc"),
         .price = (I_PRICE >= GEN_7) ? 2000 * TREASURE_FACTOR : 2100,
         .description = COMPOUND_STRING(
-            "A transparent device\n"
+            "A clear device\n"
             "overflowing with\n"
             "dubious data."),
         .pocket = POCKET_ITEMS,

--- a/src/data/items.h
+++ b/src/data/items.h
@@ -9413,7 +9413,7 @@ const struct Item gItemsInfo[] =
             "Fires an icy cold\n"
             "beam that may\n"
         #if B_USE_FROSTBITE == TRUE
-            "give the foe frostbite."),
+            "inflict frostbite."),
         #else
             "freeze the foe."),
         #endif
@@ -9429,11 +9429,13 @@ const struct Item gItemsInfo[] =
         .name = _("TM14"),
         .price = 5500,
         .description = COMPOUND_STRING(
+        #if B_USE_FROSTBITE == TRUE
+            "A snow-and-wind\n"
+            "attack that may\n"
+            "inflict frostbite."),
+        #else
             "A brutal snow-and-\n"
             "wind attack that\n"
-        #if B_USE_FROSTBITE == TRUE
-            "may give the foe frostbite."),
-        #else
             "may freeze the foe."),
         #endif
         .importance = I_REUSABLE_TMS,


### PR DESCRIPTION
## Description
The first line of the Dubious Disc description was too long. A few letters would escape the box in the Bag and in Marts. This brings them in line.

## Images
Post-fix:
![image](https://github.com/WillKolada/SpecialK-SteelRoller/assets/57021938/de1259cf-94bd-4fcc-81d4-f19bc48bff80)

Should've taken a screencap before making the change, but with "transparent," the "e" in "device" was well into the scroll menu.

## **Discord contact info**
Special K#8400
